### PR TITLE
Fix Flaky Test caused by JSONObject

### DIFF
--- a/src/test/java/org/json/junit/JSONPointerTest.java
+++ b/src/test/java/org/json/junit/JSONPointerTest.java
@@ -72,8 +72,10 @@ public class JSONPointerTest {
 
     @Test
     public void queryByEmptyKeySubObject() {
-        assertEquals( "{\"\":\"empty key of an object with an empty key\",\"subKey\":\"Some" +
-                " other value\"}", query("/obj/").toString());
+        JSONObject json = new JSONObject("{\"\":\"empty key of an object with an empty key\",\"subKey\":\"Some" +
+                " other value\"}");
+        JSONObject obj = (JSONObject) query("/obj/");
+        assertTrue(json.similar(obj));
     }
 
     @Test


### PR DESCRIPTION
### Description
Flaky Test found using [NonDex](https://github.com/TestingResearchIllinois/NonDex) by running the command -
`mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.json.junit.JSONPointerTest#queryByEmptyKeySubObject`

The logged failure for the org.json.junit.JSONPointerTest.queryByEmptyKeySubObject -

```
[ERROR] Failures: 
[ERROR]   JSONPointerTest.queryByEmptyKeySubObject:75 expected:<{"[":"empty key of an object with an empty key","subKey":"Some other value]"}> but was:<{"[subKey":"Some other value","":"empty key of an object with an empty key]"}>
```
### Investigation
The test fails at JSONPointerTest.queryByEmptyKeySubObject:75 with a comparison error while comparing an expected string and the result from org.json.junit.JSONPointerTest.query function after converting it into String. The toString function of the Object class makes no guarantees as to the iteration order of the attributes in the object. This makes the test outcome non-deterministic and the test fails whenever the toString changes the order of the properties. To fix this, the expected and actual values should be checked in a more deterministic way so that the assertions do not fail.

### Fix
Expected and Actual values can be converted into [JSONObject](https://stleary.github.io/JSON-java/org/json/JSONObject.html) and the [similar](https://stleary.github.io/JSON-java/org/json/JSONObject.html#similar-java.lang.Object-) can be used to compare these objects. As this function compares the values inside the JSONObjects without needing order, the test becomes deterministic and ensures that the flakiness from the test is removed.

The PR does not introduce a breaking change.